### PR TITLE
feat: Allow configurable update interval for weather

### DIFF
--- a/index.php
+++ b/index.php
@@ -120,6 +120,16 @@
             tempUnit = 'fahrenheit';
         }
 
+        // Get update interval from URL, default to 30 minutes
+        let updateInterval = 1800000; // Default to 30 minutes
+        const updateParam = urlParams.get('update');
+        if (updateParam) {
+            const parsedInterval = parseInt(updateParam, 10);
+            if (!isNaN(parsedInterval) && parsedInterval >= 1 && parsedInterval <= 30) {
+                updateInterval = parsedInterval * 60 * 1000;
+            }
+        }
+
         // Variables for time/date rotation
         let displayMode = 0; // 0 for time, 1 for date
         let rotationCounter = 0; // Counts seconds for rotation
@@ -267,7 +277,7 @@
                         updateTime();
                         setInterval(() => {
                             getWeatherData(latitude, longitude);
-                        }, 1800000);
+                        }, updateInterval);
                         setInterval(updateTime, 1000);
                     },
                     (error) => {

--- a/php_server.log
+++ b/php_server.log
@@ -1,0 +1,7 @@
+[Thu Aug  7 19:16:55 2025] PHP 8.3.6 Development Server (http://localhost:8000) started
+[Thu Aug  7 19:16:58 2025] 127.0.0.1:43152 Accepted
+[Thu Aug  7 19:16:58 2025] 127.0.0.1:43152 [200]: GET /index.php?update=1
+[Thu Aug  7 19:16:58 2025] 127.0.0.1:43152 Closing
+[Thu Aug  7 19:16:58 2025] 127.0.0.1:43160 Accepted
+[Thu Aug  7 19:16:58 2025] 127.0.0.1:43160 [200]: GET /proxy-geocode.php?lat=40.7128&lon=-74.006
+[Thu Aug  7 19:16:58 2025] 127.0.0.1:43160 Closing


### PR DESCRIPTION
This change allows the weather update interval to be configured via a URL parameter `update`.

- The `update` parameter accepts a value in minutes, from 1 to 30.
- If the parameter is not provided or is invalid, the update interval defaults to 30 minutes.