### PR TITLE
feat: Add installation and usage analytics

### DIFF
--- a/analytics.php
+++ b/analytics.php
@@ -1,0 +1,71 @@
+<?php
+
+// File paths for storing counts
+define('INSTALL_COUNT_FILE', 'installations.txt');
+define('USAGE_COUNT_FILE', 'usage.txt');
+
+/**
+ * Gets the current count from a specified file.
+ *
+ * @param string $filename The file to read from.
+ * @return int The current count, or 0 if the file doesn't exist.
+ */
+function get_count($filename) {
+    if (!file_exists($filename)) {
+        return 0;
+    }
+    return (int)file_get_contents($filename);
+}
+
+/**
+ * Safely increments the count in a specified file.
+ * Uses file locking to prevent race conditions.
+ *
+ * @param string $filename The file to update.
+ */
+function increment_count($filename) {
+    $count = get_count($filename);
+    $count++;
+
+    // Use file locking to prevent race conditions
+    $fp = fopen($filename, 'w');
+    if (flock($fp, LOCK_EX)) {
+        fwrite($fp, $count);
+        flock($fp, LOCK_UN);
+    }
+    fclose($fp);
+}
+
+/**
+ * Increments the installation count.
+ */
+function increment_install_count() {
+    increment_count(INSTALL_COUNT_FILE);
+}
+
+/**
+ * Increments the usage count.
+ */
+function increment_usage_count() {
+    increment_count(USAGE_COUNT_FILE);
+}
+
+/**
+ * Gets the total installation count.
+ *
+ * @return int
+ */
+function get_install_count() {
+    return get_count(INSTALL_COUNT_FILE);
+}
+
+/**
+ * Gets the total usage count.
+ *
+ * @return int
+ */
+function get_usage_count() {
+    return get_count(USAGE_COUNT_FILE);
+}
+
+?>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,15 @@
+<?php
+// Include the analytics functions
+require_once 'analytics.php';
+
+// Check if the installation has already been tracked
+if (!isset($_COOKIE['geo-weather-installed'])) {
+    // If not, increment the install count
+    increment_install_count();
+    // Set a cookie to prevent tracking this user again. Expires in 10 years.
+    setcookie('geo-weather-installed', 'true', time() + (10 * 365 * 24 * 60 * 60), "/");
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/proxy-geocode.php
+++ b/proxy-geocode.php
@@ -1,4 +1,7 @@
 <?php
+// Include the analytics functions
+require_once 'analytics.php';
+
 header('Content-Type: application/json');
 
 // IMPORTANT: Replace 'YOUR_GOOGLE_MAPS_API_KEY' with your actual API key.
@@ -40,6 +43,11 @@ curl_close($ch);
 
 // Decode the JSON response from Google
 $data = json_decode($response, true);
+
+// If the request was successful and returned results, increment the usage count
+if ($data && isset($data['status']) && $data['status'] === 'OK') {
+    increment_usage_count();
+}
 
 // Return the data to the client
 echo json_encode($data);

--- a/stats.php
+++ b/stats.php
@@ -1,0 +1,77 @@
+<?php
+// Include the analytics functions
+require_once 'analytics.php';
+
+// Get the latest counts
+$install_count = get_install_count();
+$usage_count = get_usage_count();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Geo IRL Weather - Usage Statistics</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f4f4f9;
+            color: #333;
+            margin: 0;
+            padding: 2rem;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+        .container {
+            background-color: #ffffff;
+            padding: 2rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center;
+        }
+        h1 {
+            color: #1a202c;
+            margin-bottom: 1.5rem;
+        }
+        .stats {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+        }
+        .stat-item {
+            padding: 1rem 1.5rem;
+            border: 1px solid #e2e8f0;
+            border-radius: 0.5rem;
+        }
+        .stat-item h2 {
+            font-size: 1.125rem;
+            color: #4a5568;
+            margin: 0 0 0.5rem 0;
+        }
+        .stat-item p {
+            font-size: 2.25rem;
+            font-weight: 700;
+            color: #2d3748;
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Usage Statistics</h1>
+        <div class="stats">
+            <div class="stat-item">
+                <h2>Total Installations</h2>
+                <p><?php echo number_format($install_count); ?></p>
+            </div>
+            <div class="stat-item">
+                <h2>Total API Usage</h2>
+                <p><?php echo number_format($usage_count); ?></p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a simple, file-based analytics system to track widget installations and API usage.

- A new `analytics.php` file contains the core logic for incrementing and retrieving counts from text files. File locking is used to prevent race conditions.

- `index.php` is modified to track unique installations by setting a long-term cookie. When a user visits for the first time, an installation is counted.

- `proxy-geocode.php` is updated to increment a usage counter each time it successfully fetches data from the Google Geocoding API.

- A new `stats.php` page is added to display the total installation and usage counts in a user-friendly format.