### PR TITLE
fix: Prevent crash on file permission errors in analytics

### DIFF
--- a/analytics.php
+++ b/analytics.php
@@ -27,13 +27,16 @@ function increment_count($filename) {
     $count = get_count($filename);
     $count++;
 
-    // Use file locking to prevent race conditions
-    $fp = fopen($filename, 'w');
-    if (flock($fp, LOCK_EX)) {
-        fwrite($fp, $count);
-        flock($fp, LOCK_UN);
+    // Use file locking to prevent race conditions.
+    // Suppress fopen errors with '@' in case of permission issues.
+    $fp = @fopen($filename, 'w');
+    if ($fp) { // Only proceed if the file was opened successfully
+        if (flock($fp, LOCK_EX)) {
+            fwrite($fp, $count);
+            flock($fp, LOCK_UN);
+        }
+        fclose($fp);
     }
-    fclose($fp);
 }
 
 /**


### PR DESCRIPTION
This commit fixes a bug where the application would fail to return location data if the server lacked permissions to write analytics files.

The `increment_count` function in `analytics.php` was attempting to open files for writing without handling potential errors. If `fopen` failed due to file permissions, it would generate a PHP warning, which corrupted the JSON output of `proxy-geocode.php` and caused the frontend to fail.

The function has been updated to suppress `fopen` errors with the `@` operator and to check that the file was successfully opened before attempting to write to it. This ensures that permission issues with the analytics files do not interfere with the core functionality of the widget.